### PR TITLE
Fixed some coding standard problems.

### DIFF
--- a/webform_boleto_usp.info.yml
+++ b/webform_boleto_usp.info.yml
@@ -3,7 +3,7 @@ description: 'Gera boleto USP'
 type: module
 core_version_requirement: ^8 || ^9
 dependencies:
-  - webform
-  - cpf
+  - drupal:webform
+  - drupal:cpf
 configure: webform_boleto_usp.settings
 package: Universidade de São Paulo

--- a/webform_boleto_usp.module
+++ b/webform_boleto_usp.module
@@ -2,7 +2,7 @@
 
 /**
  * @file
- * Módulo para Boleto USP
+ * Módulo para Boleto USP.
  */
 
 use Drupal\Core\Routing\RouteMatchInterface;


### PR DESCRIPTION
FILE: /var/www/html/web/modules/custom/webform_boleto_usp/webform_boleto_usp.info.yml
----------------------------------------------------------------------------------------------
FOUND 0 ERRORS AND 2 WARNINGS AFFECTING 2 LINES
----------------------------------------------------------------------------------------------
 6 | WARNING | All dependencies must be prefixed with the project name, for example "drupal:"
 7 | WARNING | All dependencies must be prefixed with the project name, for example "drupal:"
----------------------------------------------------------------------------------------------

FILE: /var/www/html/web/modules/custom/webform_boleto_usp/webform_boleto_usp.module
-----------------------------------------------------------------------------------
FOUND 1 ERROR AFFECTING 1 LINE
-----------------------------------------------------------------------------------
 5 | ERROR | [x] Doc comment short description must end with a full stop
-----------------------------------------------------------------------------------
PHPCBF CAN FIX THE 1 MARKED SNIFF VIOLATIONS AUTOMATICALLY
-----------------------------------------------------------------------------------